### PR TITLE
Fix page view page param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.6.1] - 2019-05-17
+
 ### Fixed
 
 - Pass right `page` param on `pageView` event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pass right `page` param on `pageView` event.
+- Remove duplicate `pageView` hit, removing handling of `pageInfo` event.
+
 ## [0.6.0] - 2019-05-17
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "google-analytics",
   "vendor": "vtex",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "title": "Google Analytics",
   "description": "Google Analytics app",
   "mustUpdateAt": "2019-04-03",

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -32,11 +32,23 @@ document.head!.prepend(script)
 
 let currentUrl = ''
 
+interface EventData {
+  event: string
+  eventName: string
+  currency: string
+}
+
+interface PageViewData extends EventData {
+  pageTitle: string
+  pageUrl: string
+}
+
 // Common pageview function
-const pageView = (data: any) => {
+const pageView = (origin: string, data: PageViewData) => {
   currentUrl = data.pageUrl
   ga('set', {
-    page: currentUrl.replace(location.origin, ''),
+    location: currentUrl,
+    page: currentUrl.replace(origin, ''),
     ...(data.pageTitle && {
       title: data.pageTitle,
     }),
@@ -76,11 +88,11 @@ window.addEventListener('message', e => {
   if (e.data.pageUrl && e.data.pageUrl !== currentUrl) {
     switch (e.data.event) {
       case 'pageView': {
-        pageView(e.data)
+        pageView(e.origin, e.data)
         return
       }
       case 'pageInfo': {
-        pageView(e.data)
+        pageView(e.origin, e.data)
         return
       }
       default: {

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -45,6 +45,10 @@ interface PageViewData extends EventData {
 
 // Common pageview function
 const pageView = (origin: string, data: PageViewData) => {
+  if (!data.pageUrl || data.pageUrl === currentUrl) {
+    return
+  }
+
   currentUrl = data.pageUrl
   ga('set', {
     location: currentUrl,
@@ -56,8 +60,7 @@ const pageView = (origin: string, data: PageViewData) => {
   ga('send', 'pageview')
 }
 
-// Event listener for pageview
-window.addEventListener('message', e => {
+function listener(e: MessageEvent) {
   // Event listener for productDetail
   if (e.data.event === 'productView') {
     productDetail(e.data.product)
@@ -85,15 +88,11 @@ window.addEventListener('message', e => {
     return
   }
 
-  if (e.data.pageUrl && e.data.pageUrl !== currentUrl) {
-    switch (e.data.event) {
-      case 'pageView': {
-        pageView(e.origin, e.data)
-        return
-      }
-      default: {
-        return
-      }
-    }
+  if (e.data.event === 'pageView') {
+    pageView(e.origin, e.data)
+    return
   }
-})
+}
+
+// Event listener for pageview
+window.addEventListener('message', listener)

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -91,10 +91,6 @@ window.addEventListener('message', e => {
         pageView(e.origin, e.data)
         return
       }
-      case 'pageInfo': {
-        pageView(e.origin, e.data)
-        return
-      }
       default: {
         return
       }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This fixes the page param for pageView so this wont break when this PR merges https://github.com/vtex/pixel-manager/pull/18.

#### What problem is this solving?

Pass the right page param.

#### How should this be manually tested?

Open this workspace
https://breno--storecomponents.myvtexdev.com/st-tropez-shorts/p

Check if the page param does not come with the origin:

Wrong | Right
---|---
![image](https://user-images.githubusercontent.com/284515/57807996-d52ed180-7738-11e9-91e7-c89337cc269c.png) | ![image](https://user-images.githubusercontent.com/284515/57807517-aebc6680-7737-11e9-8156-bdcac711b80f.png)

#### Screenshots or example usage

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
